### PR TITLE
Bump version to v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,7 +94,7 @@ dependencies = [
 
 [[package]]
 name = "jtd-infer"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "jtd-infer"
 description = "Generate JSON Typedef schemas from example data"
-version = "0.1.1"
+version = "0.2.0"
 license = "MIT"
 authors = ["Ulysse Carion <ulysse@segment.com>"]
 edition = "2018"


### PR DESCRIPTION
This PR bumps version to v0.2.0, and will also be the first release to use the new release tooling. As such, there is a good chance this release will have some tooling-related issues.