### PR TITLE
Bump version to v0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,7 +94,7 @@ dependencies = [
 
 [[package]]
 name = "jtd-infer"
-version = "0.2.0-test.2"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "jtd-infer"
 description = "Generate JSON Typedef schemas from example data"
-version = "0.2.0-test.2"
+version = "0.2.1"
 license = "MIT"
 authors = ["Ulysse Carion <ulysse@segment.com>"]
 edition = "2018"


### PR DESCRIPTION
This PR bumps version to v0.2.1, now that the issues with release tooling have been resolved.