### PR TITLE
Fix cargo installation instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ For all other platforms, you can download and extract the binary yourself from
 [the latest release][latest]. You can also install using `cargo` by running:
 
 ```bash
-cargo install jtd_infer
+cargo install jtd-infer
 ```
 
 ## Usage


### PR DESCRIPTION
The previous command resulted in the following output:
```
error: could not find `jtd_infer` in registry `crates-io` with version `*`
```
With `jtd-infer` it works.