### PR TITLE
Add repository link to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "jtd-infer"
 description = "Generate JSON Typedef schemas from example data"
+repository = "https://github.com/jsontypedef/json-typedef-infer"
 version = "0.2.1"
 license = "MIT"
 authors = ["Ulysse Carion <ulysse@segment.com>"]


### PR DESCRIPTION
This allows people to find the repository from crates.io or docs.rs. Especially as it isn't hosted at the author's github account.